### PR TITLE
fix: update deprecated artifact actions to v3/v4

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload Artifacts
         if: ${{ steps.changesets.outputs.hasChangesets == 'true' }}
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "apps/website/build/"
 
@@ -83,4 +83,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## 🎯 Changes

Updates deprecated GitHub Actions to their latest versions:
- `actions/upload-pages-artifact@v2` → `@v3` (uses upload-artifact@v4 internally)
- `actions/deploy-pages@v2` → `@v4`

This resolves the deprecation notice for upload-artifact@v3 and ensures compatibility with current GitHub Actions standards.

## ✅ Checklist

- [x] I have given my PR a descriptive title
- [x] Verified workflow syntax is valid
- [x] No functional changes to CI/CD behavior