### PR TITLE
fix: upgrade pnpm to v9 in CI/CD workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
         with:
-          version: 8.6.3
+          version: 9
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -26,7 +26,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Linter
         run: pnpm lint


### PR DESCRIPTION
## 🎯 Changes

- Upgrade pnpm version from 8 to 9 in both CI and CD workflows to match `lockfileVersion: '9.0'` in pnpm-lock.yaml
- Add `--frozen-lockfile` flag explicitly to CI workflow for consistency and clarity

Fixes CI failure where pnpm v8 was unable to read the v9-format lockfile.

## ✅ Checklist

- [x] I have given my PR a descriptive title
- [x] I have run `pnpm run lint` locally on my changes
- [x] I have run `pnpm run test` locally on my changes