### PR TITLE
Add tests for cell components and missing function coverage

### DIFF
--- a/packages/svelte-datagrid/src/lib/components/CheckboxCell.test.ts
+++ b/packages/svelte-datagrid/src/lib/components/CheckboxCell.test.ts
@@ -1,0 +1,89 @@
+import type { GridColumn } from '$lib/types.js';
+import { fireEvent, render } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import CheckboxCell from './CheckboxCell.svelte';
+
+interface Item {
+	active: boolean;
+}
+
+const column: GridColumn<Item> = {
+	label: 'Active',
+	dataKey: 'active',
+	width: 80
+};
+
+describe('CheckboxCell', () => {
+	beforeEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('should render a checkbox input', () => {
+		const { container } = render(CheckboxCell<Item>, {
+			row: { active: true },
+			column,
+			rowIndex: 0,
+			virtualRowIndex: 0
+		});
+
+		const input = container.querySelector('input[type="checkbox"]');
+		expect(input).not.toBeNull();
+	});
+
+	it('should render checked when row value is true', () => {
+		const { container } = render(CheckboxCell<Item>, {
+			row: { active: true },
+			column,
+			rowIndex: 0,
+			virtualRowIndex: 0
+		});
+
+		const input = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+		expect(input.checked).toBe(true);
+	});
+
+	it('should render unchecked when row value is false', () => {
+		const { container } = render(CheckboxCell<Item>, {
+			row: { active: false },
+			column,
+			rowIndex: 0,
+			virtualRowIndex: 0
+		});
+
+		const input = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+		expect(input.checked).toBe(false);
+	});
+
+	it('should dispatch valueUpdated event when clicked', async () => {
+		const { component, container } = render(CheckboxCell<Item>, {
+			row: { active: false },
+			column,
+			rowIndex: 2,
+			virtualRowIndex: 2
+		});
+
+		const handler = vi.fn();
+		component.$on('valueUpdated', handler);
+
+		const input = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+		await fireEvent.click(input);
+
+		expect(handler).toHaveBeenCalledOnce();
+		const event = handler.mock.calls[0][0] as CustomEvent;
+		expect(event.detail.rowIndex).toBe(2);
+		expect(event.detail.virtualRowIndex).toBe(2);
+		expect(event.detail.column).toEqual(column);
+	});
+
+	it('should set correct id on input', () => {
+		const { container } = render(CheckboxCell<Item>, {
+			row: { active: true },
+			column,
+			rowIndex: 3,
+			virtualRowIndex: 3
+		});
+
+		const input = container.querySelector('input');
+		expect(input?.id).toBe('grid-data-row-3-active');
+	});
+});

--- a/packages/svelte-datagrid/src/lib/components/SelectCell.test.ts
+++ b/packages/svelte-datagrid/src/lib/components/SelectCell.test.ts
@@ -1,0 +1,126 @@
+import type { GridColumn } from '$lib/types.js';
+import { fireEvent, render } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SelectCell from './SelectCell.svelte';
+
+interface Item {
+	color: string;
+}
+
+const column: GridColumn<Item> = {
+	label: 'Color',
+	dataKey: 'color',
+	width: 120,
+	options: [
+		{ value: 'red', label: 'Red' },
+		{ value: 'green', label: 'Green' },
+		{ value: 'blue', label: 'Blue' }
+	]
+};
+
+describe('SelectCell', () => {
+	beforeEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('should render a select element', () => {
+		const { container } = render(SelectCell<Item>, {
+			row: { color: 'red' },
+			column,
+			rowIndex: 0,
+			virtualRowIndex: 0
+		});
+
+		const select = container.querySelector('select');
+		expect(select).not.toBeNull();
+	});
+
+	it('should render all options', () => {
+		const { container } = render(SelectCell<Item>, {
+			row: { color: 'red' },
+			column,
+			rowIndex: 0,
+			virtualRowIndex: 0
+		});
+
+		const options = container.querySelectorAll('option');
+		expect(options).toHaveLength(3);
+	});
+
+	it('should have the matching option selected', () => {
+		const { container } = render(SelectCell<Item>, {
+			row: { color: 'green' },
+			column,
+			rowIndex: 0,
+			virtualRowIndex: 0
+		});
+
+		const options = container.querySelectorAll('option');
+		const selectedOption = Array.from(options).find((o) => o.selected);
+		expect(selectedOption?.value).toBe('green');
+	});
+
+	it('should not render select when options is not an array', () => {
+		const columnNoOptions: GridColumn<Item> = { label: 'Color', dataKey: 'color', width: 120 };
+		const { container } = render(SelectCell<Item>, {
+			row: { color: 'red' },
+			column: columnNoOptions,
+			rowIndex: 0,
+			virtualRowIndex: 0
+		});
+
+		const select = container.querySelector('select');
+		expect(select).toBeNull();
+	});
+
+	it('should dispatch valueUpdated event when selection changes', async () => {
+		const { component, container } = render(SelectCell<Item>, {
+			row: { color: 'red' },
+			column,
+			rowIndex: 1,
+			virtualRowIndex: 1
+		});
+
+		const handler = vi.fn();
+		component.$on('valueUpdated', handler);
+
+		const select = container.querySelector('select') as HTMLSelectElement;
+		await fireEvent.change(select, { target: { value: 'blue' } });
+
+		expect(handler).toHaveBeenCalledOnce();
+		const event = handler.mock.calls[0][0] as CustomEvent;
+		expect(event.detail.rowIndex).toBe(1);
+		expect(event.detail.column).toEqual(column);
+	});
+
+	it('should render label from function option', () => {
+		const columnWithFnLabel: GridColumn<Item> = {
+			label: 'Color',
+			dataKey: 'color',
+			width: 120,
+			options: [{ value: 'red', label: () => 'Dynamic Red' }]
+		};
+
+		const { container } = render(SelectCell<Item>, {
+			row: { color: 'red' },
+			column: columnWithFnLabel,
+			rowIndex: 0,
+			virtualRowIndex: 0
+		});
+
+		const option = container.querySelector('option');
+		expect(option?.textContent?.trim()).toBe('Dynamic Red');
+	});
+
+	it('should set correct id on select', () => {
+		const { container } = render(SelectCell<Item>, {
+			row: { color: 'red' },
+			column,
+			rowIndex: 4,
+			virtualRowIndex: 4
+		});
+
+		const select = container.querySelector('select');
+		expect(select?.id).toBe('grid-data-row-4-color');
+	});
+});

--- a/packages/svelte-datagrid/src/lib/components/TextboxCell.test.ts
+++ b/packages/svelte-datagrid/src/lib/components/TextboxCell.test.ts
@@ -1,0 +1,82 @@
+import type { GridColumn } from '$lib/types.js';
+import { fireEvent, render } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { writable } from 'svelte/store';
+import TextboxCell from './TextboxCell.svelte';
+
+interface Item {
+	name: string;
+}
+
+const column: GridColumn<Item> = {
+	label: 'Name',
+	dataKey: 'name',
+	width: 120
+};
+
+function renderTextboxCell(props: {
+	row: Item;
+	column: GridColumn<Item>;
+	rowIndex: number;
+	virtualRowIndex: number;
+}) {
+	const activeRow = writable(-1);
+	return render(TextboxCell<Item>, {
+		props,
+		context: new Map([['activeRow', activeRow]])
+	});
+}
+
+describe('TextboxCell', () => {
+	beforeEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('should render a text input', () => {
+		const { container } = renderTextboxCell({
+			row: { name: 'Alice' },
+			column,
+			rowIndex: 0,
+			virtualRowIndex: 0
+		});
+
+		const input = container.querySelector('input[type="text"]');
+		expect(input).not.toBeNull();
+	});
+
+	it('should set correct id on input', () => {
+		const { container } = renderTextboxCell({
+			row: { name: 'Alice' },
+			column,
+			rowIndex: 5,
+			virtualRowIndex: 5
+		});
+
+		const input = container.querySelector('input');
+		expect(input?.id).toBe('grid-data-row-5-name');
+	});
+
+	it('should dispatch valueUpdated event on input', async () => {
+		const { component, container } = renderTextboxCell({
+			row: { name: 'Alice' },
+			column,
+			rowIndex: 0,
+			virtualRowIndex: 0
+		});
+
+		const handler = vi.fn();
+		component.$on('valueUpdated', handler);
+
+		const input = container.querySelector('input') as HTMLInputElement;
+		input.value = 'Bob';
+		await fireEvent.input(input);
+
+		await new Promise((r) => setTimeout(r, 10));
+
+		expect(handler).toHaveBeenCalledOnce();
+		const event = handler.mock.calls[0][0] as CustomEvent;
+		expect(event.detail.value).toBe('Bob');
+		expect(event.detail.rowIndex).toBe(0);
+		expect(event.detail.column).toEqual(column);
+	});
+});

--- a/packages/svelte-datagrid/src/lib/functions/calculateFunctions.test.ts
+++ b/packages/svelte-datagrid/src/lib/functions/calculateFunctions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	MIN_COLUMN_WIDTH,
+	calculateDefaultRowsPerPage,
 	calculateGridSpaceWidth,
 	calculatePercent,
 	calculateXPositions,
@@ -8,6 +9,7 @@ import {
 	getVisibleRowsIndexes,
 	updateColumnWidths
 } from './calculateFunctions.js';
+import { MAX_DEFAULT_ROWS_PER_PAGE } from '$lib/configurations.js';
 import type { GridColumn } from '$lib/types.js';
 
 describe('updateColumnWidths', () => {
@@ -94,6 +96,18 @@ describe('getVisibleRowsIndexes', () => {
 
 		expect(result).toEqual(expected);
 	});
+
+	it('should clamp start to 0 when scrollTop is negative', () => {
+		const result = getVisibleRowsIndexes(20, -100, 100, 100, 0);
+
+		expect(result.start).toBe(0);
+	});
+
+	it('should clamp end to totalRows when visible rows exceed total', () => {
+		const result = getVisibleRowsIndexes(20, 0, 1000, 5, 0);
+
+		expect(result.end).toBe(5);
+	});
 });
 
 describe('getRowTop', () => {
@@ -105,6 +119,26 @@ describe('getRowTop', () => {
 		const result = getRowTop(rowIndex, rowHeight);
 
 		expect(result).toEqual(expected);
+	});
+});
+
+describe('calculateDefaultRowsPerPage', () => {
+	it('should return rowsLength when less than MAX_DEFAULT_ROWS_PER_PAGE', () => {
+		const result = calculateDefaultRowsPerPage(5);
+
+		expect(result).toBe(5);
+	});
+
+	it('should return MAX_DEFAULT_ROWS_PER_PAGE when rowsLength exceeds it', () => {
+		const result = calculateDefaultRowsPerPage(MAX_DEFAULT_ROWS_PER_PAGE + 1);
+
+		expect(result).toBe(MAX_DEFAULT_ROWS_PER_PAGE);
+	});
+
+	it('should return MAX_DEFAULT_ROWS_PER_PAGE when rowsLength equals it', () => {
+		const result = calculateDefaultRowsPerPage(MAX_DEFAULT_ROWS_PER_PAGE);
+
+		expect(result).toBe(MAX_DEFAULT_ROWS_PER_PAGE);
 	});
 });
 

--- a/packages/svelte-datagrid/src/lib/functions/gridHelpers.test.ts
+++ b/packages/svelte-datagrid/src/lib/functions/gridHelpers.test.ts
@@ -37,4 +37,18 @@ describe('swapGridColums', () => {
 
 		expect(columns).toEqual(columnsCopy);
 	});
+
+	it('should return same column order when swapping a column with itself', () => {
+		const columns = [
+			{ label: 'Column 1' },
+			{ label: 'Column 2' },
+			{ label: 'Column 3' }
+		] as GridColumn<unknown>[];
+
+		const result = swapGridColums(columns, 1, 1);
+
+		expect(result.columns).toEqual(columns);
+		expect(result.from).toEqual(columns[1]);
+		expect(result.to).toEqual(columns[1]);
+	});
 });


### PR DESCRIPTION
## Summary

- Add test files for `CheckboxCell`, `SelectCell`, and `TextboxCell` components (previously untested)
- Extend `calculateFunctions.test.ts` with tests for `calculateDefaultRowsPerPage` and edge cases in `getVisibleRowsIndexes` (negative scrollTop, end clamped to total rows)
- Extend `gridHelpers.test.ts` with a same-column swap edge case

## Test plan

- [x] All 43 tests pass (`pnpm test` in `packages/svelte-datagrid`)
- [x] `CheckboxCell`: render, checked/unchecked state, `valueUpdated` dispatch, correct input id
- [x] `SelectCell`: render, options count, selected option, no select when options absent, `valueUpdated` dispatch, function label, correct select id
- [x] `TextboxCell`: render, correct id, `valueUpdated` dispatch on input (with Svelte context mocked)
- [x] `calculateDefaultRowsPerPage`: below, equal, and above `MAX_DEFAULT_ROWS_PER_PAGE`
- [x] `getVisibleRowsIndexes`: negative scrollTop clamp, end clamped to totalRows
- [x] `swapGridColums`: same-index swap returns unchanged order