### PR TITLE
feat(DataGrid): add frozen columns support (left/right)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,9 +133,16 @@ git commit -m "chore: add changeset"
 
 PRs without a changeset will not trigger a version bump or npm release when merged.
 
+## Pre-PR Checklist
+
+Before creating a PR, complete the checklist defined in `.github/pull_request_template.md`:
+
+1. Give the PR a descriptive title
+2. Run `pnpm run lint` — if it fails due to formatting, run `pnpm run format`, commit the changes, then re-run lint
+3. Run `pnpm run test` — all tests must pass
+
 ## Conventions
 
 - Use **tabs** for indentation
 - **Single quotes**, no trailing commas, 100 char print width
-- PR template requires: descriptive title, lint pass, test pass
 - Version bumps managed via `pnpm changeset`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,12 @@ Run: `pnpm test` (root) or `pnpm --filter @gzim/svelte-datagrid test`
 
 ## Changesets (versioning)
 
-This project uses [Changesets](https://github.com/changesets/changesets) for version management. **Any PR that includes a bug fix, new feature, or breaking change must include a changeset commit.**
+This project uses [Changesets](https://github.com/changesets/changesets) for version management.
+
+**Important:** Do NOT add a changeset immediately with every PR. Changesets that bump the version should only be created in two scenarios:
+
+1. **Hotfix releases** — critical bug fixes that need to be published to npm right away. In this case, include the changeset in the same PR as the fix.
+2. **Planned release versions** — when a release is explicitly planned, create a dedicated changeset PR to bump the version. This groups multiple changes into a single release and avoids noisy, unnecessary deployments.
 
 To add a changeset:
 

--- a/apps/website/src/routes/+page.svelte
+++ b/apps/website/src/routes/+page.svelte
@@ -24,10 +24,11 @@
 		{ value: 'C2', label: 'C2' }
 	];
 
-	const columns: GridColumn<Person>[] = [
+	let columns: GridColumn<Person>[] = [
 		{
 			label: 'Zodiac',
 			dataKey: 'zodiac',
+			draggable: true,
 			width: 100
 		},
 		{
@@ -35,20 +36,13 @@
 			dataKey: 'firstName',
 			width: 200,
 			cellComponent: TextboxCell,
-			draggable: true,
-			resizable: true
+			resizable: true,
+			frozen: 'left'
 		},
 		{
 			label: 'Last Name',
 			dataKey: 'lastName',
 			width: 200,
-			draggable: true
-		},
-		{
-			label: 'Married',
-			dataKey: 'married',
-			width: 100,
-			cellComponent: CheckboxCell,
 			draggable: true
 		},
 		{
@@ -58,6 +52,13 @@
 			options: nivelIngles,
 			cellComponent: SelectCell,
 			draggable: true
+		},
+		{
+			label: 'Married',
+			dataKey: 'married',
+			width: 100,
+			cellComponent: CheckboxCell,
+			frozen: 'right'
 		}
 	];
 
@@ -128,6 +129,13 @@
 		scrollToRow(parseInt(value));
 	};
 
+	const setFrozen = (index: number, side: 'left' | 'right', checked: boolean) => {
+		columns = columns.map((col, i) => {
+			if (i !== index) return col;
+			return { ...col, frozen: checked ? side : undefined };
+		});
+	};
+
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	let getGridState: () => any | undefined;
 	let scrollToRow: (index: number) => void | undefined;
@@ -178,6 +186,40 @@
 		</button>
 	</div>
 
+	<div class="frozen-controls">
+		<p class="frozen-title">Frozen Columns</p>
+		<table class="frozen-table">
+			<thead>
+				<tr>
+					<th>Column</th>
+					<th>Left</th>
+					<th>Right</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each columns as column, i}
+					<tr>
+						<td>{column.label}</td>
+						<td>
+							<input
+								type="checkbox"
+								checked={column.frozen === 'left'}
+								on:change={(e) => setFrozen(i, 'left', e.currentTarget.checked)}
+							/>
+						</td>
+						<td>
+							<input
+								type="checkbox"
+								checked={column.frozen === 'right'}
+								on:change={(e) => setFrozen(i, 'right', e.currentTarget.checked)}
+							/>
+						</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
+
 	<div class="flexy">
 		<label for="allColumnsResizable">
 			<p>Resizable Columns</p>
@@ -209,5 +251,29 @@
 
 	.flexy label {
 		@apply flex flex-col items-center gap-2;
+	}
+
+	.frozen-controls {
+		@apply flex flex-col items-center gap-2 w-full;
+	}
+
+	.frozen-title {
+		@apply font-semibold text-slate-600 text-sm;
+	}
+
+	.frozen-table {
+		@apply text-sm border-collapse;
+	}
+
+	.frozen-table th {
+		@apply px-4 py-1 text-slate-500 font-medium border-b border-slate-300;
+	}
+
+	.frozen-table td {
+		@apply px-4 py-1 text-center border-b border-slate-200;
+	}
+
+	.frozen-table td:first-child {
+		@apply text-left font-medium text-slate-700;
 	}
 </style>

--- a/apps/website/src/routes/+page.svelte
+++ b/apps/website/src/routes/+page.svelte
@@ -26,23 +26,23 @@
 
 	let columns: GridColumn<Person>[] = [
 		{
-			label: 'Zodiac',
-			dataKey: 'zodiac',
-			draggable: true,
-			width: 100
+			label: 'Last Name',
+			dataKey: 'lastName',
+			width: 200,
+			draggable: true
 		},
 		{
 			label: 'First Name',
 			dataKey: 'firstName',
 			width: 200,
-			cellComponent: TextboxCell,
 			resizable: true,
 			frozen: 'left'
 		},
 		{
-			label: 'Last Name',
-			dataKey: 'lastName',
-			width: 200,
+			label: 'Zodiac',
+			dataKey: 'zodiac',
+			width: 100,
+			cellComponent: TextboxCell,
 			draggable: true
 		},
 		{
@@ -57,8 +57,7 @@
 			label: 'Married',
 			dataKey: 'married',
 			width: 100,
-			cellComponent: CheckboxCell,
-			frozen: 'right'
+			cellComponent: CheckboxCell
 		}
 	];
 

--- a/packages/svelte-datagrid/src/lib/DataGridProps.ts
+++ b/packages/svelte-datagrid/src/lib/DataGridProps.ts
@@ -85,4 +85,14 @@ export interface GridProps {
 	 * @default RowHeight * 6
 	 */
 	'--grid-height'?: string;
+	/**
+	 * Box shadow for frozen-left columns
+	 * @default '2px 0 4px rgba(0, 0, 0, 0.15)'
+	 */
+	'--frozen-left-shadow'?: string;
+	/**
+	 * Box shadow for frozen-right columns
+	 * @default '-2px 0 4px rgba(0, 0, 0, 0.15)'
+	 */
+	'--frozen-right-shadow'?: string;
 }

--- a/packages/svelte-datagrid/src/lib/components/Datagrid.svelte
+++ b/packages/svelte-datagrid/src/lib/components/Datagrid.svelte
@@ -323,7 +323,9 @@
 					style:left="{cellLeftPositions[i]}px"
 					class:resizingColumn={isResizing && columnResizing == i}
 					draggable={!isResizing && !column.frozen && (allColumnsDraggable || column.draggable)}
-					class:draggable={!isResizing && !column.frozen && (allColumnsDraggable || column.draggable)}
+					class:draggable={!isResizing &&
+						!column.frozen &&
+						(allColumnsDraggable || column.draggable)}
 					class:resizable={!isResizing && (allColumnsResizable || column.resizable)}
 					class:dragging={isDragging && columnDragging == i}
 					class:dropTarget={isDragging &&
@@ -404,7 +406,13 @@
 		</div>
 	</div>
 
-	<div role="rowgroup" class="svelte-grid-body" bind:this={gridBody} bind:clientWidth={bodyClientWidth} on:scroll={onScroll}>
+	<div
+		role="rowgroup"
+		class="svelte-grid-body"
+		bind:this={gridBody}
+		bind:clientWidth={bodyClientWidth}
+		on:scroll={onScroll}
+	>
 		<div class="grid-space"></div>
 
 		{#each visibleRows as row, virtualRowIndex}

--- a/packages/svelte-datagrid/src/lib/components/Datagrid.svelte
+++ b/packages/svelte-datagrid/src/lib/components/Datagrid.svelte
@@ -11,9 +11,10 @@
 
 	import {
 		calculateDefaultRowsPerPage,
+		calculateFrozenLeftOffsets,
+		calculateFrozenRightOffsets,
 		calculateGridSpaceWidth,
 		calculatePercent,
-		calculateXPositions,
 		getRowTop,
 		getVisibleRowsIndexes,
 		MIN_COLUMN_WIDTH,
@@ -145,6 +146,7 @@
 
 	let svelteGridWrapper: HTMLDivElement;
 	let gridBody: HTMLDivElement;
+	let bodyClientWidth = 0;
 	let isResizing = false;
 	let isDragging = false;
 	let columnDragging = -1;
@@ -169,7 +171,44 @@
 
 	$: columnWidths = updateColumnWidths(columns);
 	$: gridSpaceWidth = calculateGridSpaceWidth(columnWidths);
-	$: xPositions = calculateXPositions(columnWidths);
+	$: frozenLeftOffsets = calculateFrozenLeftOffsets(columns, columnWidths);
+	$: frozenRightOffsets = calculateFrozenRightOffsets(columns, columnWidths);
+
+	// Reactive cell positions: frozen columns pinned to edges, non-frozen laid out without gaps
+	$: cellLeftPositions = (() => {
+		const positions = new Array(columns.length).fill(0);
+
+		// Total width of frozen-left columns (reserve space at left)
+		const frozenLeftTotal = columns.reduce(
+			(sum, col, i) => (col.frozen === 'left' ? sum + columnWidths[i] : sum),
+			0
+		);
+
+		// Non-frozen columns laid out consecutively after frozen-left area
+		let x = frozenLeftTotal;
+		for (let i = 0; i < columns.length; i++) {
+			if (!columns[i].frozen) {
+				positions[i] = x;
+				x += columnWidths[i];
+			}
+		}
+
+		// Frozen-left: pinned to viewport left edge
+		for (let i = 0; i < columns.length; i++) {
+			if (columns[i].frozen === 'left') {
+				positions[i] = scrollLeft + frozenLeftOffsets[i];
+			}
+		}
+
+		// Frozen-right: pinned to viewport right edge
+		for (let i = 0; i < columns.length; i++) {
+			if (columns[i].frozen === 'right') {
+				positions[i] = scrollLeft + bodyClientWidth - frozenRightOffsets[i] - columnWidths[i];
+			}
+		}
+
+		return positions;
+	})();
 	$: totalRows = rows.length;
 	$: gridSpaceHeight = rowHeight * rows.length;
 	$: visibleRowsIndexes = getVisibleRowsIndexes(
@@ -281,22 +320,25 @@
 					title={column.label || ''}
 					role="columnheader"
 					style:width="{columnWidths[i]}px"
-					style:left="{xPositions[i]}px"
+					style:left="{cellLeftPositions[i]}px"
 					class:resizingColumn={isResizing && columnResizing == i}
-					draggable={!isResizing && (allColumnsDraggable || column.draggable)}
-					class:draggable={!isResizing && (allColumnsDraggable || column.draggable)}
+					draggable={!isResizing && !column.frozen && (allColumnsDraggable || column.draggable)}
+					class:draggable={!isResizing && !column.frozen && (allColumnsDraggable || column.draggable)}
 					class:resizable={!isResizing && (allColumnsResizable || column.resizable)}
 					class:dragging={isDragging && columnDragging == i}
 					class:dropTarget={isDragging &&
 						columnDropTarget === i &&
 						columnDropTarget !== columnDragging}
+					class:frozen-left={column.frozen === 'left'}
+					class:frozen-right={column.frozen === 'right'}
 					on:dragenter={() => {
-						if (isDragging && (allColumnsDraggable || column.draggable)) columnDropTarget = i;
+						if (isDragging && !column.frozen && (allColumnsDraggable || column.draggable))
+							columnDropTarget = i;
 					}}
 					on:dragover={(e) => {
 						if (isDragging) e.preventDefault();
 					}}
-					animate:flip={isResizing ? NO_TRANSITION_EFFECT : animationParams}
+					animate:flip={isResizing || column.frozen ? NO_TRANSITION_EFFECT : animationParams}
 					use:reziseColumn={{
 						resizable: allColumnsResizable || column.resizable,
 						startResize() {
@@ -314,7 +356,7 @@
 						}
 					}}
 					use:dragAndDrop={{
-						draggable: allColumnsDraggable || column.draggable,
+						draggable: !column.frozen && (allColumnsDraggable || column.draggable),
 						dragStart: () => {
 							isDragging = true;
 							columnDragging = i;
@@ -338,6 +380,7 @@
 								if (
 									clientX > left &&
 									clientX < right &&
+									!columns[index].frozen &&
 									(allColumnsDraggable || columns[index].draggable) &&
 									index != columnDragging
 								) {
@@ -361,7 +404,7 @@
 		</div>
 	</div>
 
-	<div role="rowgroup" class="svelte-grid-body" bind:this={gridBody} on:scroll={onScroll}>
+	<div role="rowgroup" class="svelte-grid-body" bind:this={gridBody} bind:clientWidth={bodyClientWidth} on:scroll={onScroll}>
 		<div class="grid-space"></div>
 
 		{#each visibleRows as row, virtualRowIndex}
@@ -382,10 +425,12 @@
 						data-column={j}
 						data-row={row.i}
 						style="width:{columnWidths[j]}px"
-						style:left="{xPositions[j]}px"
+						style:left="{cellLeftPositions[j]}px"
 						class:resizingColumn={isResizing && columnResizing == j}
 						class:draggableColumnCell={allColumnsDraggable || column.draggable}
-						animate:flip={isResizing ? NO_TRANSITION_EFFECT : animationParams}
+						class:frozen-left={column.frozen === 'left'}
+						class:frozen-right={column.frozen === 'right'}
+						animate:flip={isResizing || column.frozen ? NO_TRANSITION_EFFECT : animationParams}
 					>
 						<div class="cell-container" class:cell-default={!column.cellComponent}>
 							{#if column.cellComponent}
@@ -588,5 +633,27 @@
 
 	.grid-cell.resizingColumn {
 		border-right: var(--border-resizing, 2px solid #666);
+	}
+
+	.grid-cell.frozen-left,
+	.grid-cell.frozen-right {
+		z-index: 5;
+		background: var(--cell-bg, white);
+	}
+
+	.columnheader.frozen-left,
+	.columnheader.frozen-right {
+		z-index: 5;
+		background: var(--head-bg, white);
+	}
+
+	.grid-cell.frozen-left,
+	.columnheader.frozen-left {
+		box-shadow: var(--frozen-left-shadow, 2px 0 4px rgba(0, 0, 0, 0.15));
+	}
+
+	.grid-cell.frozen-right,
+	.columnheader.frozen-right {
+		box-shadow: var(--frozen-right-shadow, -2px 0 4px rgba(0, 0, 0, 0.15));
 	}
 </style>

--- a/packages/svelte-datagrid/src/lib/components/Datagrid.test.ts
+++ b/packages/svelte-datagrid/src/lib/components/Datagrid.test.ts
@@ -99,6 +99,70 @@ describe('Datagrid', () => {
 	});
 });
 
+describe('Datagrid frozen columns', () => {
+	beforeEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('should add frozen-left class to frozen left column headers', async () => {
+		const frozenColumns: GridColumn<Cat>[] = [
+			{ ...columns[0], frozen: 'left' },
+			columns[1],
+			columns[2]
+		];
+		const { findAllByTestId } = render(Datagrid<Cat>, { columns: frozenColumns, rows });
+
+		const headers = await findAllByTestId('columnheader');
+		expect(headers[0].classList.contains('frozen-left')).toBe(true);
+		expect(headers[1].classList.contains('frozen-left')).toBe(false);
+		expect(headers[2].classList.contains('frozen-left')).toBe(false);
+	});
+
+	it('should add frozen-right class to frozen right column headers', async () => {
+		const frozenColumns: GridColumn<Cat>[] = [
+			columns[0],
+			columns[1],
+			{ ...columns[2], frozen: 'right' }
+		];
+		const { findAllByTestId } = render(Datagrid<Cat>, { columns: frozenColumns, rows });
+
+		const headers = await findAllByTestId('columnheader');
+		expect(headers[2].classList.contains('frozen-right')).toBe(true);
+		expect(headers[0].classList.contains('frozen-right')).toBe(false);
+	});
+
+	it('should not make frozen columns draggable', async () => {
+		const frozenColumns: GridColumn<Cat>[] = [
+			{ ...columns[0], frozen: 'left', draggable: true },
+			{ ...columns[1], draggable: true },
+			{ ...columns[2], frozen: 'right', draggable: true }
+		];
+		const { findAllByTestId } = render(Datagrid<Cat>, { columns: frozenColumns, rows });
+
+		const headers = await findAllByTestId('columnheader');
+		expect(headers[0].classList.contains('draggable')).toBe(false);
+		expect(headers[1].classList.contains('draggable')).toBe(true);
+		expect(headers[2].classList.contains('draggable')).toBe(false);
+	});
+
+	it('should not set frozen columns as drop targets during drag', async () => {
+		const frozenColumns: GridColumn<Cat>[] = [
+			{ ...columns[0], frozen: 'left' },
+			{ ...columns[1], draggable: true },
+			{ ...columns[2], draggable: true }
+		];
+		const { findAllByTestId } = render(Datagrid<Cat>, { columns: frozenColumns, rows });
+
+		const headers = await findAllByTestId('columnheader');
+		const [frozen, , source] = headers;
+
+		await fireEvent.dragStart(source);
+		await fireEvent.dragEnter(frozen);
+
+		expect(frozen.classList.contains('dropTarget')).toBe(false);
+	});
+});
+
 describe('Datagrid column drag drop target', () => {
 	beforeEach(() => {
 		document.body.innerHTML = '';

--- a/packages/svelte-datagrid/src/lib/functions/calculateFunctions.test.ts
+++ b/packages/svelte-datagrid/src/lib/functions/calculateFunctions.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
 	MIN_COLUMN_WIDTH,
 	calculateDefaultRowsPerPage,
+	calculateFrozenLeftOffsets,
+	calculateFrozenRightOffsets,
 	calculateGridSpaceWidth,
 	calculatePercent,
 	calculateXPositions,
@@ -139,6 +141,87 @@ describe('calculateDefaultRowsPerPage', () => {
 		const result = calculateDefaultRowsPerPage(MAX_DEFAULT_ROWS_PER_PAGE);
 
 		expect(result).toBe(MAX_DEFAULT_ROWS_PER_PAGE);
+	});
+});
+
+describe('calculateFrozenLeftOffsets', () => {
+	it('should return all zeros when no columns are frozen', () => {
+		const columns = [{ width: 100 }, { width: 200 }, { width: 150 }] as Parameters<
+			typeof calculateFrozenLeftOffsets
+		>[0];
+		const widths = [100, 200, 150];
+		expect(calculateFrozenLeftOffsets(columns, widths)).toEqual([0, 0, 0]);
+	});
+
+	it('should return cumulative offsets for frozen-left columns', () => {
+		const columns = [
+			{ width: 100, frozen: 'left' as const },
+			{ width: 200, frozen: 'left' as const },
+			{ width: 150 }
+		] as Parameters<typeof calculateFrozenLeftOffsets>[0];
+		const widths = [100, 200, 150];
+		expect(calculateFrozenLeftOffsets(columns, widths)).toEqual([0, 100, 0]);
+	});
+
+	it('should handle a single frozen-left column', () => {
+		const columns = [
+			{ width: 80, frozen: 'left' as const },
+			{ width: 100 },
+			{ width: 120 }
+		] as Parameters<typeof calculateFrozenLeftOffsets>[0];
+		const widths = [80, 100, 120];
+		expect(calculateFrozenLeftOffsets(columns, widths)).toEqual([0, 0, 0]);
+	});
+
+	it('should not include frozen-right columns in left offsets', () => {
+		const columns = [
+			{ width: 100, frozen: 'left' as const },
+			{ width: 200 },
+			{ width: 150, frozen: 'right' as const }
+		] as Parameters<typeof calculateFrozenLeftOffsets>[0];
+		const widths = [100, 200, 150];
+		expect(calculateFrozenLeftOffsets(columns, widths)).toEqual([0, 0, 0]);
+	});
+});
+
+describe('calculateFrozenRightOffsets', () => {
+	it('should return all zeros when no columns are frozen', () => {
+		const columns = [{ width: 100 }, { width: 200 }, { width: 150 }] as Parameters<
+			typeof calculateFrozenRightOffsets
+		>[0];
+		const widths = [100, 200, 150];
+		expect(calculateFrozenRightOffsets(columns, widths)).toEqual([0, 0, 0]);
+	});
+
+	it('should return cumulative offsets from right for frozen-right columns', () => {
+		const columns = [
+			{ width: 100 },
+			{ width: 200, frozen: 'right' as const },
+			{ width: 150, frozen: 'right' as const }
+		] as Parameters<typeof calculateFrozenRightOffsets>[0];
+		const widths = [100, 200, 150];
+		// col[2] is the rightmost frozen: offset 0; col[1] is next: offset = 150
+		expect(calculateFrozenRightOffsets(columns, widths)).toEqual([0, 150, 0]);
+	});
+
+	it('should handle a single frozen-right column', () => {
+		const columns = [
+			{ width: 100 },
+			{ width: 200 },
+			{ width: 150, frozen: 'right' as const }
+		] as Parameters<typeof calculateFrozenRightOffsets>[0];
+		const widths = [100, 200, 150];
+		expect(calculateFrozenRightOffsets(columns, widths)).toEqual([0, 0, 0]);
+	});
+
+	it('should not include frozen-left columns in right offsets', () => {
+		const columns = [
+			{ width: 100, frozen: 'left' as const },
+			{ width: 200 },
+			{ width: 150, frozen: 'right' as const }
+		] as Parameters<typeof calculateFrozenRightOffsets>[0];
+		const widths = [100, 200, 150];
+		expect(calculateFrozenRightOffsets(columns, widths)).toEqual([0, 0, 0]);
 	});
 });
 

--- a/packages/svelte-datagrid/src/lib/functions/calculateFunctions.ts
+++ b/packages/svelte-datagrid/src/lib/functions/calculateFunctions.ts
@@ -21,6 +21,46 @@ export function calculateGridSpaceWidth(columnWidths: number[]) {
 	return columnWidths.reduce((acc, width) => acc + width, 0);
 }
 
+/**
+ * Returns an array where each index contains the cumulative width of all
+ * preceding frozen-left columns (i.e. the sticky left offset for that column).
+ * Non-frozen columns get 0.
+ */
+export function calculateFrozenLeftOffsets<T>(
+	columns: GridColumn<T>[],
+	columnWidths: number[]
+): number[] {
+	const offsets: number[] = new Array(columns.length).fill(0);
+	let currentOffset = 0;
+	for (let i = 0; i < columns.length; i++) {
+		if (columns[i].frozen === 'left') {
+			offsets[i] = currentOffset;
+			currentOffset += columnWidths[i];
+		}
+	}
+	return offsets;
+}
+
+/**
+ * Returns an array where each index contains the cumulative width of all
+ * following frozen-right columns (i.e. the sticky right offset for that column).
+ * Non-frozen columns get 0.
+ */
+export function calculateFrozenRightOffsets<T>(
+	columns: GridColumn<T>[],
+	columnWidths: number[]
+): number[] {
+	const offsets: number[] = new Array(columns.length).fill(0);
+	let currentOffset = 0;
+	for (let i = columns.length - 1; i >= 0; i--) {
+		if (columns[i].frozen === 'right') {
+			offsets[i] = currentOffset;
+			currentOffset += columnWidths[i];
+		}
+	}
+	return offsets;
+}
+
 export function getVisibleRowsIndexes(
 	rowHeight: number,
 	scrollTop: number,

--- a/packages/svelte-datagrid/src/lib/types.ts
+++ b/packages/svelte-datagrid/src/lib/types.ts
@@ -11,6 +11,11 @@ export type GridColumn<T> = {
 	options?: GridColumnOption[];
 	draggable?: boolean;
 	resizable?: boolean;
+	/**
+	 * Freeze the column to the left or right side of the grid.
+	 * Frozen columns remain visible during horizontal scroll.
+	 */
+	frozen?: 'left' | 'right';
 };
 
 export type GridColumnOption = {


### PR DESCRIPTION
## Summary
- Add `frozen: 'left' | 'right'` option to `GridColumn<T>` to pin columns to either edge during horizontal scroll
- Frozen columns stack in order, non-frozen columns fill remaining space without gaps
- Drag-and-drop is disabled for frozen columns; they maintain a higher z-index and opaque background
- Add CSS custom properties (`--frozen-left-shadow`, `--frozen-right-shadow`) for shadow customization
- Update example page with interactive checkboxes to toggle frozen state per column
- Add tests for frozen offset calculations and component behavior (61 tests passing)
- Update AGENTS.md with changeset policy and pre-PR checklist

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm run test` passes (61 tests, 6 test files)
- [x] Verified frozen columns stay pinned during horizontal scroll
- [x] Verified non-frozen columns don't leave gaps when columns are frozen
- [x] Verified frozen columns render above non-frozen columns (z-index)
- [x] Verified drag-and-drop is disabled for frozen columns