### PR TITLE
fix(cd): add NODE_AUTH_TOKEN and upgrade npm for npm publish auth

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,6 +33,9 @@ jobs:
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+
       - run: pnpm install --frozen-lockfile
 
       - name: Package
@@ -45,6 +48,7 @@ jobs:
           publish: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
       - name: Print Changesets Outputs


### PR DESCRIPTION
## 🎯 Changes

Fixes npm publish failures in the CD workflow by:
- Adding `NODE_AUTH_TOKEN` environment variable to the changesets action, which is required for npm authentication when using `setup-node` with `registry-url`
- Upgrading npm to latest before publishing to ensure compatibility with provenance signing and token handling

This resolves the E404 "Not Found" error that occurred when attempting to publish scoped packages to npm.

## ✅ Checklist

- [x] PR has a descriptive title
- [x] No linting or tests needed for workflow changes